### PR TITLE
Added functionality to map iqcToolbox delta objects to rct delta obje…

### DIFF
--- a/src/functions/frontend/lftToRct.m
+++ b/src/functions/frontend/lftToRct.m
@@ -1,4 +1,4 @@
-function uss_out = lftToRct(ulft_input)
+function [uss_out, delta_map] = lftToRct(ulft_input)
 %% lftToRct for converting Ulft objects to uss objects.
 %
 %     uss_out = lftToRct(ulft_input)
@@ -61,8 +61,15 @@ function uss_out = lftToRct(ulft_input)
     d = m(dim_in+1:end, dim_out+1:end);
     
     ss_lft = ss(a, b, c, d, ts);
-    
+    delta_map = delta_mapper(ulft_input);
     uss_out = lft(uncertainties, ss_lft);
+end
+
+function mapped_delta = delta_mapper(in_lft)
+    mapped_delta = containers.Map;
+    for i = 1:length(in_lft.delta.deltas)
+        mapped_delta(in_lft.delta.deltas{i}.name) = in_lft.delta.deltas{i};
+    end
 end
 
 %%  CHANGELOG

--- a/src/functions/frontend/rctToLft.m
+++ b/src/functions/frontend/rctToLft.m
@@ -1,4 +1,4 @@
-function lft_out = rctToLft(rct_obj) 
+function lft_out = rctToLft(rct_obj, varargin) 
 %% RCTTOLFT for converting ureal, ultidyn, umat, uss objects to Ulft objects.
 %
 %     lft_out = rctToLft(rct_obj)
@@ -11,6 +11,8 @@ function lft_out = rctToLft(rct_obj)
 %     ---------
 %       Input:
 %         rct_obj : ureal, ultidyn, umat, or uss object
+%         varagin : optional containers.Map object of delta names to rct
+%                   deltas. 
 %       Output:
 %         lft_out : Ulft object :: the resultant lft
 %
@@ -23,7 +25,7 @@ function lft_out = rctToLft(rct_obj)
 
 %% Calling appropriate functions for different input arguments
     if isa(rct_obj, 'uss')
-        lft_out = ussToLft(rct_obj);
+        lft_out = ussToLft(rct_obj, varargin);
     elseif isa(rct_obj, 'umat')
         lft_out = umatToLft(rct_obj);
     elseif isa(rct_obj, 'ultidyn')
@@ -74,7 +76,7 @@ function lft_out = umatToLft(umat_in)
     lft_out = Ulft(a, b, c, d, delta_object);
 end
 
-function lft_out = ussToLft(uss_in)
+function lft_out = ussToLft(uss_in, varargin)
 
     [m, delta_std, ~, delta_norm] = lftdata(uss_in);
     m = [m.A, m.B; m.C, m.D];
@@ -124,9 +126,15 @@ function lft_out = ussToLft(uss_in)
     end
     
     delta_cell = cell(size(delta_norm,1), 1);
-    
-    for i = 1:size(delta_norm)
-        delta_cell{i} = toDelta(delta_norm{i});
+    map = varargin{1}{1};
+    if nargin == 1
+        for i = 1:size(delta_norm)
+            delta_cell{i} = toDelta(delta_norm{i});
+        end
+    elseif nargin == 2
+        for i = 1:size(delta_norm)
+            delta_cell{i} = toDelta(delta_norm{i}, map);
+        end
     end
     
     % check to see if there are any states/whether any time deltas were

--- a/src/functions/frontend/toDelta.m
+++ b/src/functions/frontend/toDelta.m
@@ -1,7 +1,7 @@
-function delta_out = toDelta(rct_obj)
+function delta_out = toDelta(rct_obj, varargin)
 %% TODELTA - Function for converting uncertain RCT objects to iqcToolbox Deltas.
 %
-%     delta_out = toDelta(rct_obj)
+%     delta_out = toDelta(rct_obj, varagin)
 %
 %     If input is ultidyn, output is a DeltaDlti.
 %     If input is ureal, output is a DeltaSlti. 
@@ -11,6 +11,7 @@ function delta_out = toDelta(rct_obj)
 %     ---------
 %       Input:
 %         rct_obj : ureal or ultidyn (from Robust Control Toolbox)
+%         varagin : map of delta names and objects from lftToRct
 %       output:
 %         delta_out : Delta object :: the resultant delta
 %
@@ -33,8 +34,10 @@ if nargin == 1
         error('toDelta:toDelta', ['When providing a single argument for toDelta, ',...
               'that input must be a ureal or ultidyn']);
     end
-
+elseif nargin == 2
+    delta_out = normalizeLft(toLft(varargin{1}(erase(rct_obj.Name, 'Normalized')))).delta.deltas{1};
 end
+
 end
 
 function delta_out = ultidynToDelta(ulti_in)


### PR DESCRIPTION
Adds mapping between iqcToolbox deltas and RCT deltas. Specifically maintains deltas for non-convertible Deltas. Closes #46 