### PR TITLE
hotfix-011-installing_sdpt3_failure

### DIFF
--- a/scripts/installIqcToolbox.m
+++ b/scripts/installIqcToolbox.m
@@ -265,12 +265,14 @@ y = 'y';
 Y = y;
 n = 'n';
 N = n;
-affirm = false;
-while ~affirm
-    yesno = input([dependency, ' is not detected on your system and ',...
-                  'must be installed. Do you wish to install? [''y''/''n'']',...
-                  '\n ']);
-    affirm = strcmp(yesno, 'y');
+yesno = input([dependency, ' is not detected on your system and ',...
+              'must be installed. Do you wish to install? [''y''/''n'']',...
+              '\n ']);
+affirm = strcmp(yesno, 'y');
+if ~affirm
+    error('installIqcToolbox:affirmInstallation',...
+          ['Installation cannot proceed unless you agree to install ',...
+           dependency])
 end
 
 %%  CHANGELOG

--- a/scripts/installIqcToolbox.m
+++ b/scripts/installIqcToolbox.m
@@ -59,7 +59,8 @@ end
 
 % SDPT3
 try
-    B = graph2(10);
+    B = diag([1, 1, 1, 1], 1);
+    B = B + B';
     feas = 1;
     [blk,At,C,b] = thetaproblem(B, feas);
     ops.printlevel = 0;


### PR DESCRIPTION
Closes #58 . Also changes the behavior for affirming installation; rather than keeping the user in an infinite loop, it throws an error.