### PR TITLE
ci-005-addressing_failing_tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v1
         with:
-          release: R2022a
+          release: R2022b
 
       # Install iqcToolbox
       - name: Install iqcToolbox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       # Sets up MATLAB on the GitHub Actions runner
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v1
-#        with:
-#          release: ${{ R2021a }}
+        with:
+          release: ${{ R2022a }}
 
       # Install iqcToolbox
       - name: Install iqcToolbox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v1
         with:
-          release: ${{ R2022a }}
+          release: R2022a
 
       # Install iqcToolbox
       - name: Install iqcToolbox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v1
         with:
-          release: R2022b
+          release: R2022a
 
       # Install iqcToolbox
       - name: Install iqcToolbox


### PR DESCRIPTION
Addressing #76.  This is a temporary fix until further clarification from the MATLAB Github CI team on the impact of using Matlab R2022b for CI tests.