### PR TITLE
hotfix-015-remove_ltiobject.empty_calls

### DIFF
--- a/src/classes/Multiplier/MultiplierConstantDelay.m
+++ b/src/classes/Multiplier/MultiplierConstantDelay.m
@@ -32,9 +32,9 @@ classdef MultiplierConstantDelay < MultiplierDelta
 properties
     basis_length double
     basis_poles double
-    basis_function tf
-    basis_realization ss
-    block_realization ss
+    basis_function tf = tf() % tf.empty throws errors from R22b and on
+    basis_realization ss = ss() % ss.empty throws errors from R22b and on
+    block_realization ss = ss() % ss.empty throws errors from R22b and on
     delay_max double
     dim_outin double
 end

--- a/src/classes/Multiplier/MultiplierConstantDelay2.m
+++ b/src/classes/Multiplier/MultiplierConstantDelay2.m
@@ -35,9 +35,9 @@ classdef MultiplierConstantDelay2 < MultiplierDelta
 properties
     basis_length double
     basis_poles double
-    basis_function tf
-    basis_realization ss
-    basis_delay ss
+    basis_function tf = tf() % tf.empty throws errors from R22b and on
+    basis_realization ss = ss() % ss.empty throws errors from R22b and on
+    basis_delay ss = ss() % ss.empty throws errors from R22b and on
     delay_max double
     dim_outin double
     delay_filter_eps double

--- a/src/classes/Multiplier/MultiplierDlti.m
+++ b/src/classes/Multiplier/MultiplierDlti.m
@@ -32,8 +32,8 @@ classdef MultiplierDlti < MultiplierDelta
 properties
     basis_length double
     basis_poles double
-    basis_function tf
-    basis_realization ss
+    basis_function tf = tf() % tf.empty throws errors from R22b and on
+    basis_realization ss = ss() % ss.empty throws errors from R22b and on
     upper_bound double
     dim_out double
     dim_in double

--- a/src/classes/Multiplier/MultiplierSlti.m
+++ b/src/classes/Multiplier/MultiplierSlti.m
@@ -33,9 +33,9 @@ classdef MultiplierSlti < MultiplierDelta
 properties
     basis_length double
     basis_poles double
-    basis_function tf
-    basis_realization ss
-    block_realization ss
+    basis_function tf = tf() % tf.empty throws errors from R22b and on
+    basis_realization ss = ss() % ss.empty throws errors from R22b and on
+    block_realization ss = ss() % ss.empty throws errors from R22b and on
     upper_bound double
     dim_outin double
 end

--- a/src/classes/Multiplier/MultiplierSltvRateBndImpl.m
+++ b/src/classes/Multiplier/MultiplierSltvRateBndImpl.m
@@ -58,8 +58,8 @@ properties (SetAccess = immutable)
 end
 
 properties (SetAccess = private)
-    basis_function tf
-    basis_realization ss   
+    basis_function tf = tf() % tf.empty throws errors from R22b and on
+    basis_realization ss = ss() % ss.empty throws errors from R22b and on
     block_realization struct
 end
 


### PR DESCRIPTION
Closes #76 (after it was reopened from #77).
Previously, class properties with `tf` and `ss` type were defined as:
```
classdef FooClass

properties
    bar_tf tf
    bar_ss ss 
...
```
This type definition for properties is problematic for R2022b, since the Control Systems Toolbox will now throw an error if you call `tf.empty` or `ss.empty`.  Accordingly, this PR replaces these property specifications with:
```

properties
    bar_tf tf = tf()
    bar_ss ss = ss()
...
```
